### PR TITLE
Import `PanicInfo` from std instead of core

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -54,9 +54,9 @@ use core::{
   mem::replace,
   num::NonZeroU8,
   ops::*,
-  panic::PanicInfo,
   sync::atomic::{AtomicBool, Ordering},
 };
+use std::panic::PanicInfo;
 
 mod curses_common;
 use curses_common::*;


### PR DESCRIPTION
This fixes https://github.com/rust-lang/rust/issues/128890